### PR TITLE
assigning value to list with .value is deprecated

### DIFF
--- a/lib/controllers/productcontroller.dart
+++ b/lib/controllers/productcontroller.dart
@@ -17,7 +17,7 @@ class ProductController extends GetxController {
       isLoading(true);
       var products = await RemoteServices.fetchProducts();
       if (products != null) {
-        productList.value = products;
+        productList.assignAll(products);
       }
     } finally {
       isLoading(false);


### PR DESCRIPTION
assigning value to list with .value is deprecated. Replacing with list.assignAll(data_list)